### PR TITLE
Fix Battle schema where imageUrl was missing type

### DIFF
--- a/src/battle/model/Battle.ts
+++ b/src/battle/model/Battle.ts
@@ -20,7 +20,7 @@ const battleSchema = new Schema<BattleStructure>({
     required: true,
   },
   imageUrl: {
-    String,
+    type: String,
   },
   description: {
     type: String,


### PR DESCRIPTION
Fix Battle schema where imageUrl was missing type, this was preventing to return Battles with imageUrl